### PR TITLE
Fix up DOS_Drive_Cache::GetShortName, used by overlay drive.

### DIFF
--- a/src/dos/drive_cache.cpp
+++ b/src/dos/drive_cache.cpp
@@ -266,6 +266,7 @@ void DOS_Drive_Cache::CacheOut(const char* path, bool ignoreLastDir) {
 
 //	LOG_DEBUG("DIR: Caching out %s : dir %s",expand,dir->orgname);
 	// delete file objects...
+	//Maybe check if it is a file and then only delete the file and possibly the long name. instead of all objects in the dir.
 	for(Bit32u i=0; i<dir->fileList.size(); i++) {
 		if (dirSearch[srchNr]==dir->fileList[i]) dirSearch[srchNr] = 0;
 		DeleteFileInfo(dir->fileList[i]); dir->fileList[i] = 0;
@@ -286,22 +287,22 @@ bool DOS_Drive_Cache::GetShortName(const char* fullname, char* shortname) {
 	char expand[CROSS_LEN] = {0};
 	CFileInfo* curDir = FindDirInfo(fullname,expand);
 
+	const char* pos = strrchr(fullname,CROSS_FILESPLIT);
+	if (pos) pos++; else return false;
+
 	std::vector<CFileInfo*>::size_type filelist_size = curDir->longNameList.size();
 	if (GCC_UNLIKELY(filelist_size<=0)) return false;
 
-	Bits low		= 0;
-	Bits high		= (Bits)(filelist_size-1);
-	Bits mid, res;
-
-	while (low<=high) {
-		mid = (low+high)/2;
-		res = strcmp(fullname,curDir->longNameList[mid]->orgname);
-		if (res>0)	low  = mid+1; else
-		if (res<0)	high = mid-1; 
-		else {
-			strcpy(shortname,curDir->longNameList[mid]->shortname);
+	// The orgname part of the list is not sorted (shortname is)! So we can only walk through it.
+	for(Bitu i = 0; i < filelist_size; i++) {
+#if defined (WIN32) || defined (OS2)                        /* Win 32 & OS/2*/
+		if (strcasecmp(pos,curDir->longNameList[i]->orgname) == 0) {
+#else
+		if (strcmp(pos,curDir->longNameList[i]->orgname) == 0) {
+#endif
+			strcpy(shortname,curDir->longNameList[i]->shortname);
 			return true;
-		};
+		}
 	}
 	return false;
 }


### PR DESCRIPTION
git-svn-id: http://svn.code.sf.net/p/dosbox/code-0/dosbox/trunk@4195 ed541006-0bf7-43e9-8c4d-6fc63c346d47